### PR TITLE
End AFK mode when a player moves or interacts

### DIFF
--- a/src/main/java/ml/noahc3/nickafkpartypack/Events/EventListener.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Events/EventListener.java
@@ -112,6 +112,26 @@ public class EventListener implements Listener {
         } catch (NullPointerException ignored) { }
     }
 
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+
+        PersistentDataContainer data = player.getPersistentDataContainer();
+        data.remove(Constants.afkKey);
+
+        updatePlayerStamps(player);
+    }
+
+    @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+
+        PersistentDataContainer data = player.getPersistentDataContainer();
+        data.remove(Constants.afkKey);
+
+        updatePlayerStamps(player);
+    }
+
     private static void updatePlayerStamps(Player player) {
         Constants.afkTimestamps.put(player.getUniqueId(), System.currentTimeMillis());
         Constants.playerYaw.put(player.getUniqueId(), player.getLocation().getYaw());

--- a/src/main/java/ml/noahc3/nickafkpartypack/Events/EventListener.java
+++ b/src/main/java/ml/noahc3/nickafkpartypack/Events/EventListener.java
@@ -115,6 +115,7 @@ public class EventListener implements Listener {
     @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
+        if (! Tasks.isPlayerAfk(player)) return;
 
         PersistentDataContainer data = player.getPersistentDataContainer();
         data.remove(Constants.afkKey);
@@ -125,6 +126,7 @@ public class EventListener implements Listener {
     @EventHandler (priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
+        if (! Tasks.isPlayerAfk(player)) return;
 
         PersistentDataContainer data = player.getPersistentDataContainer();
         data.remove(Constants.afkKey);


### PR DESCRIPTION
This adds event listeners for the `PlayerMoveEvent` & `PlayerInteractEvent`. AFK mode will be ended for the triggering player.